### PR TITLE
Fix wott-agent build in balena image.

### DIFF
--- a/aws-iot/Dockerfile.template
+++ b/aws-iot/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3-stretch-build
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.5-stretch-build
 
 WORKDIR /usr/src/app
 

--- a/google-core-iot/Dockerfile.template
+++ b/google-core-iot/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3-stretch-build
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.5-stretch-build
 
 WORKDIR /usr/src/app
 

--- a/wott-agent/Dockerfile.template
+++ b/wott-agent/Dockerfile.template
@@ -5,11 +5,11 @@ WORKDIR /usr/src/app
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl-dev libffi-dev git-core pkg-config libsystemd-dev xtables-addons-common libip4tc0 libiptc0 libip6tc0 && \
+    apt-get install -y --no-install-recommends libssl-dev libffi-dev git-core pkg-config libsystemd-dev xtables-addons-common libip4tc0 libiptc0 libip6tc0 iptables && \
     apt-get clean
 RUN pip3 install --upgrade setuptools pip
 
-RUN pip3 install git+https://github.com/GreatFruitOmsk/agent.git@fix-snap
+RUN pip3 install git+https://github.com/WoTTsecurity/agent.git@master
 
 # Balena specific path override
 ENV CERT_PATH=/data/wott/certs

--- a/wott-agent/Dockerfile.template
+++ b/wott-agent/Dockerfile.template
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl-dev libffi-dev git-core pkg-config libsystemd-dev && \
+    apt-get install -y --no-install-recommends libssl-dev libffi-dev git-core pkg-config libsystemd-dev xtables-addons-common libip4tc0 libiptc0 libip6tc0 && \
     apt-get clean
 RUN pip3 install --upgrade setuptools pip
 
@@ -14,6 +14,4 @@ RUN pip3 install git+https://github.com/GreatFruitOmsk/agent.git@fix-snap
 # Balena specific path override
 ENV CERT_PATH=/data/wott/certs
 
-COPY start.sh /start.sh
-
-CMD /start.sh
+CMD wott-agent daemon

--- a/wott-agent/Dockerfile.template
+++ b/wott-agent/Dockerfile.template
@@ -1,16 +1,15 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3-stretch-build
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.5-stretch-build
+
 
 WORKDIR /usr/src/app
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl-dev libffi-dev git-core && \
+    apt-get install -y --no-install-recommends libssl-dev libffi-dev git-core pkg-config libsystemd-dev && \
     apt-get clean
+RUN pip3 install --upgrade setuptools pip
 
-RUN pip install -U pip
-
-# Don't pin releases yet
-RUN pip install git+https://github.com/WoTTsecurity/agent.git@7b399029c8da911bd1ef46aabe1079ce815f71b4
+RUN pip3 install git+https://github.com/GreatFruitOmsk/agent.git@fix-snap
 
 # Balena specific path override
 ENV CERT_PATH=/data/wott/certs


### PR DESCRIPTION
Closes #1 
Pin all balena images to 3.5-python.